### PR TITLE
Updated for python3 and added plaintext conversion

### DIFF
--- a/ENML_PY/__init__.py
+++ b/ENML_PY/__init__.py
@@ -2,12 +2,31 @@
 # -*- coding: utf-8 -*-
 import os
 from bs4 import BeautifulSoup
+import html2text
 MIME_TO_EXTESION_MAPPING = {
     'image/png': '.png',
     'image/jpg': '.jpg',
     'image/jpeg': '.jpg',
     'image/gif': '.gif'
 }
+
+REPLACEMENTS = [
+    ("&quot;", "\""),
+    ("&amp;apos;", "'"),
+    ("&apos;", "'"),
+    ("&amp;", "&"),
+    ("&lt;", "<"),
+    ("&gt;", ">"),
+    ("&laquo;", "<<"),
+    ("&raquo;", ">>"),
+    ("&#039;", "'"),
+    ("&#8220;", "\""),
+    ("&#8221;", "\""),
+    ("&#8216;", "\'"),
+    ("&#8217;", "\'"),
+    ("&#9632;", ""),
+    ("&#8226;", "-")]
+
 
 def ENMLToHTML(content, pretty=True, header=True, **kwargs):
     """
@@ -19,7 +38,7 @@ def ENMLToHTML(content, pretty=True, header=True, **kwargs):
     Returns True if the resource must be kept in HTML, False otherwise.
     :type media_fiter: callable object with prototype: `bool func(hash_str, mime_type)`
     """
-    soup = BeautifulSoup(content)
+    soup = BeautifulSoup(content, "html.parser")
 
     todos = soup.find_all('en-todo')
     for todo in todos:
@@ -62,6 +81,22 @@ def ENMLToHTML(content, pretty=True, header=True, **kwargs):
 
     return content
 
+
+def ENMLToText(content, pretty=True, header=True, **kwargs):
+    """
+    converts ENML string into HTML string then converts HTML string to plain text
+
+    :param header: If True, note is wrapped in a <HTML><BODY> block.
+    :type header: bool
+    :param media_filter: optional callable object used to filter undesired resources.
+    Returns True if the resource must be kept in HTML, False otherwise.
+    :type media_fiter: callable object with prototype: `bool func(hash_str, mime_type)`
+    """
+    html = ENMLToHTML(content, pretty, header)
+    text = str(html2text.html2text(html.decode('utf-8')))
+    for entity, replacement in REPLACEMENTS:
+        text = text.replace(entity, replacement)
+    return text
 
 class MediaStore(object):
     def __init__(self, note_store, note_guid):

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 ENML_PY
 =======
 
-This is a python library for converting ENML (Evernote Markup Language, http://dev.evernote.com/start/core/enml.php) to/from HTML.
+This is a python library for converting ENML (Evernote Markup Language, http://dev.evernote.com/start/core/enml.php) to/from HTML and plain text.
 
 Dependencies
 =======
 - [BeautifulSoup 4 (a.k.a. bs4)](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-beautiful-soup)
+- [html2text](https://pypi.python.org/pypi/html2text)
 - [Evernote SDK for python](http://dev.evernote.com/start/guides/python.php)
 
 Usage
@@ -33,6 +34,16 @@ Convert without prettifying
 >>> html = enml.ENMLToHTML(note, pretty=False)
 >>> print html
 <html><body>hello world</body></html>
+```
+
+Convert to plaintext
+-----
+```python
+>>> import ENML_PY as enml
+>>> note = "<en-note>hello world</en-note>"
+>>> text = enml.ENMLToText(note, pretty=False)
+>>> print text
+hello world
 ```
 
 Convert with saving resources


### PR DESCRIPTION
## Python 3
```python
soup = BeautifulSoup(content)
```
Has been converted to avoid a BeautifulSoup warning that occurs in
Python 3.6. It now reads:
```python
soup = BeautifulSoup(content, "html.parser")
```

## Plaintext
Added a the ENMLToText function, which converts to HTML then to text,
as described in the blurb that
hadn’t been previously implemented.